### PR TITLE
Add nusricq311.cn domain

### DIFF
--- a/lib/domains/cn/nusricq311.txt
+++ b/lib/domains/cn/nusricq311.txt
@@ -1,0 +1,2 @@
+新加坡国立大学重庆研究院
+NUS (Chongqing) Research Institude


### PR DESCRIPTION
The university official website URL is https://www.nusricq.cn/